### PR TITLE
fix(backend): padronizar resposta de /videos com DTO (sem props)

### DIFF
--- a/api/src/http/presenters/video.presenter.ts
+++ b/api/src/http/presenters/video.presenter.ts
@@ -1,0 +1,13 @@
+import { Video } from '../../domain/entities/Video'
+
+export class VideoPresenter {
+  static toHTTP(video: Video) {
+    return {
+      id: video.id,
+      title: video.title,
+      description: video.description,
+      providerUrl: video.providerUrl,
+      createdAt: video.createdAt.toISOString()
+    }
+  }
+}

--- a/api/src/http/routes/videos.routes.ts
+++ b/api/src/http/routes/videos.routes.ts
@@ -1,12 +1,19 @@
-import { Router } from 'express';
-import { InMemoryVideoRepository } from '../../infra/db/InMemoryVideoRepository';
+import { Router } from "express";
+import { InMemoryVideoRepository } from "../../infra/db/InMemoryVideoRepository";
+import { VideoPresenter } from "../presenters/video.presenter";
 
-const router = Router();
-const videoRepo = new InMemoryVideoRepository();
+const videosRouter = Router();
+const repo = new InMemoryVideoRepository();
 
-router.get('/videos', async (_req, res) => {
-  const videos = await videoRepo.listAll();
-  res.json(videos);
+videosRouter.get("/videos", async (_req, res) => {
+  const list = await repo.listAll();
+  return res.json(list.map(VideoPresenter.toHTTP));
 });
 
-export default router;
+videosRouter.get("/videos/:id", async (req, res) => {
+  const video = await repo.findById(req.params.id);
+  if (!video) return res.status(404).json({ error: "Vídeo não encontrado" });
+  return res.json(VideoPresenter.toHTTP(video));
+});
+
+export default videosRouter;

--- a/api/src/infra/db/InMemoryVideoRepository.ts
+++ b/api/src/infra/db/InMemoryVideoRepository.ts
@@ -4,14 +4,14 @@ import { VideoRepository } from '../../domain/repositories/VideoRepository'
 const seed: Video[] = [
   new Video({
     id: 'v1',
-    title: 'SOLID fica FÁCIL com Essas Ilustrações',
+    title: 'Conceito SOLID de uma forma fácil e ilustrativa',
     description: 'Conceitos SOLID',
     providerUrl: 'https://www.youtube.com/watch?v=6SfrO3D4dHM',
     createdAt: new Date()
   }),
   new Video({
     id: 'v2',
-    title: 'Design Patterns // Dicionário do Programador',
+    title: 'Design Patterns',
     description: 'Explicação rápida e didática de design patterns.',
     providerUrl: 'https://www.youtube.com/watch?v=J-lHpiu-Twk',
     createdAt: new Date()


### PR DESCRIPTION
### Alterações
- Removido wrapper `props` da resposta de /videos
- Criado DTO para padronizar saída
- Resposta agora retorna diretamente os campos do vídeo

### Motivo
Facilitar o consumo no frontend sem precisar acessar `props`.
