### PR TITLE
feat(frontend): adicionar página Home consumindo vídeos da API

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,16 @@
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Header from "./components/Header";
+import Home from "./Pages/Home";
 
 export default function App() {
   return (
-    <div className="min-h-screen bg-neutral-950 text-white">
-      <Header />
-      <main className="mx-auto max-w-6xl px-4 py-8">
-        <h1 className="text-2xl font-semibold">Bem-vindo à VideoFeedback </h1>
-        <p className="text-white/60">
-          Aqui você poderá assistir vídeos, deixar notas e visualizar feedbacks.
-        </p>
-      </main>
-    </div>
+    <BrowserRouter>
+      <div className="min-h-screen bg-neutral-950 text-white">
+        <Header />
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
   );
 }

--- a/web/src/Pages/Home.tsx
+++ b/web/src/Pages/Home.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api";
+import type { Video } from "@/types/Video";
+
+export default function Home() {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.get<Video[]>("/videos")
+      .then(res => setVideos(res.data))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="mx-auto max-w-6xl px-4 py-8">
+      <h1 className="text-2xl font-semibold">Vídeos</h1>
+
+      {loading && <p className="mt-4 text-white/70">Carregando...</p>}
+
+      <ul className="mt-6 grid gap-4 sm:grid-cols-2">
+        {videos.map(v => (
+          <li key={v.id} className="rounded-xl border border-white/10 bg-neutral-900 p-4 shadow-sm">
+            <h2 className="text-lg font-medium">{v.title}</h2>
+            <p className="mt-1 text-sm text-white/60 line-clamp-2">{v.description}</p>
+
+            {/* os links para /video/:id e /feedbacks/:id virão na próxima branch */}
+            <div className="mt-3 flex gap-3">
+              <button className="rounded-md bg-white/10 px-3 py-1.5 text-sm text-white/80">
+                Assistir (em breve)
+              </button>
+              <button className="rounded-md border border-white/10 px-3 py-1.5 text-sm text-white/60">
+                Ver feedbacks (em breve)
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {!loading && videos.length === 0 && (
+        <p className="mt-4 text-white/70">Nenhum vídeo disponível.</p>
+      )}
+    </div>
+  );
+}

--- a/web/src/api/index.ts
+++ b/web/src/api/index.ts
@@ -1,4 +1,5 @@
-import axios from 'axios';
+import axios from "axios";
+
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,6 +1,0 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
-
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
-}

--- a/web/src/types/Video.ts
+++ b/web/src/types/Video.ts
@@ -1,0 +1,7 @@
+export interface Video {
+  id: string;
+  title: string;
+  description: string;
+  providerUrl: string;
+  createdAt: string;
+}


### PR DESCRIPTION
Este PR adiciona a primeira versão da Home do frontend.

- Criação da página `Home`
- Integração com a API `/videos` para listar os vídeos
- Estrutura inicial para exibir título e descrição dos vídeos
- Botões de ação "Assistir" e "Ver feedbacks" (ainda não implementados)

Este é o primeiro passo para a navegação completa (Home → Vídeo → Feedbacks).
